### PR TITLE
Prevent printing empty tweet in streaming

### DIFF
--- a/twty.go
+++ b/twty.go
@@ -367,7 +367,9 @@ func main() {
 				continue
 			}
 			last = []byte{}
-			showTweets(tweets[:], *verbose)
+			if tweets[0].Identifier != "" {
+				showTweets(tweets[:], *verbose)
+			}
 		}
 	} else if flag.NArg() == 0 {
 		if len(*inreply) > 0 {


### PR DESCRIPTION
In streaming mode, some empty lines are printed like ":". This PR skips those tweets.