### PR TITLE
Print posted tweet id

### DIFF
--- a/twty.go
+++ b/twty.go
@@ -230,6 +230,13 @@ func postTweet(token *oauth.Credentials, url_ string, opt map[string]string) err
 		log.Println("failed to get timeline:", err)
 		return err
 	}
+	var tweet Tweet
+	err = json.NewDecoder(res.Body).Decode(&tweet)
+	if err != nil {
+		log.Println("failed to parse new tweet:", err)
+		return err
+	}
+	log.Println("tweeted:", tweet.Identifier)
 	return nil
 }
 


### PR DESCRIPTION
Prints posted id likes this:
`2015/01/26 13:08:27 tweeted: 559563491871181032`

I'm not sure if the timestamp matters. Maybe it would be better to change `log.Println` to `fmt.Println`. WDYT?