### PR TITLE
TIME_LAYOUT was invalid.

### DIFF
--- a/twty.go
+++ b/twty.go
@@ -233,7 +233,7 @@ var replacer = strings.NewReplacer(
 	"\t", " ",
 )
 
-const TIME_LAYOUT = "Mon Jan 01 15:04:05 -0700 2006"
+const TIME_LAYOUT = "Mon Jan 02 15:04:05 -0700 2006"
 
 func toLocalTime(timeStr string) string {
 	timeValue, err := time.Parse(TIME_LAYOUT, timeStr)


### PR DESCRIPTION
Sorry, this bug is included in my previous pull request #13 (Feburary 2017)

It causes that the date of `twty -v` is not localtime but UTC now (March 2017).