### PR TITLE
Replace EMOJIs' literal from raw-strings to \uXXXX style.

### DIFF
--- a/twty.go
+++ b/twty.go
@@ -23,6 +23,11 @@ import (
 	"github.com/garyburd/go-oauth/oauth"
 )
 
+const (
+	EMOJI_RED_HEART    = "\u2764"
+	EMOJI_HIGH_VOLTAGE = "\u26A1"
+)
+
 // Account hold information about account
 type Account struct {
 	TimeZone struct {
@@ -410,7 +415,7 @@ func main() {
 			log.Fatal("failed to create favorite:", err)
 		}
 		color.Set(color.FgHiRed)
-		fmt.Print("❤")
+		fmt.Print(EMOJI_RED_HEART)
 		color.Set(color.Reset)
 		fmt.Println("favorited")
 	} else if *stream {
@@ -458,7 +463,7 @@ func main() {
 				log.Fatal("failed to retweet:", err)
 			}
 			color.Set(color.FgHiYellow)
-			fmt.Print("⚡")
+			fmt.Print(EMOJI_HIGH_VOLTAGE)
 			color.Set(color.Reset)
 			fmt.Println("retweeted:", tweet.Identifier)
 		} else {


### PR DESCRIPTION
In spite of not editing lines those lines including Emojis ( "Red Heart" and "High voltage" )  in the source file, some editors often break them.

So, at making a patch, I have to remove broken lines from the source file.
Would you those Emojis to \uXXXX style with this patch.

Details I means (in Japanese):
（機能改善ではなく、パッチを作る際の「完全に個人的な都合・要望」で恐縮ですが、絵文字を含む行がエディターで開く度に壊れてしまい、毎回 `git add -p -e` でパッチから除外しています。もしご不都合がなければ、本プルリクにありますとおり、`\uXXXX` 形式のリテラルに絵文字を変えさせていただけるとその手間が省けて助かります。ご検討の程、よろしくお願いいたします）